### PR TITLE
Bump nymag-handlebars version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lodash": "^4.17.4",
     "node-fetch": "^1.6.3",
     "nymag-fs": "^1.0.1",
-    "nymag-handlebars": "3.1.1"
+    "nymag-handlebars": "3.2.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Bump `nymag-handlebars` version to 3.2.0 in package.json