### PR TITLE
Inline vs. Tag Edit Mode Assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,3 +5,4 @@ const setup = require('./lib/setup');
 module.exports.render = require('./lib/render');
 module.exports.addRootPath = setup.addRootPath;
 module.exports.addHelpers = setup.addHelpers;
+module.exports.configureRender = setup.configureRender;

--- a/lib/media.js
+++ b/lib/media.js
@@ -171,8 +171,8 @@ function append(mediaMap, editMode = false, site) {
       mediaProps.styles = combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG);
       mediaProps.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
     } else {
-      mediaProps.styles = injectTags(mediaMap.styles, site, STYLE_TAG);
-      mediaProps.scripts = injectTags(mediaMap.scripts, site, SCRIPT_TAG);
+      mediaProps.styles = module.exports.editStylesTags ? injectTags(mediaMap.styles, site, STYLE_TAG) : combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG);
+      mediaProps.scripts = module.exports.editScriptsTags ? injectTags(mediaMap.scripts, site, SCRIPT_TAG) : combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
     }
 
     return bluebird.props(mediaProps).then(combinedFiles => {
@@ -183,4 +183,22 @@ function append(mediaMap, editMode = false, site) {
   };
 }
 
+/**
+ * Set the values for inlining vs tagging edit mode styles/scripts
+ *
+ * @param  {Object|Boolean} options
+ */
+function configure(options) {
+  if (options && _.isObject(options)) {
+    module.exports.editStylesTags = options.styles || false;
+    module.exports.editScriptsTags = options.scripts || false;
+  } else {
+    module.exports.editStylesTags = options;
+    module.exports.editScriptsTags = options;
+  }
+}
+
 module.exports.append = append;
+module.exports.configure = configure;
+module.exports.editStylesTags = false;
+module.exports.editScriptsTags = false;

--- a/lib/media.js
+++ b/lib/media.js
@@ -140,26 +140,38 @@ function appendMediaToBottom(scripts, html) {
   return splice(html, index, scripts);
 }
 
+function injectTags(fileArray, site, tag) {
+  var links = _.map(fileArray, function (file) {
+    return `<link rel="stylesheet" type="text/css" href="${site.assetPath}${file}">`
+  }).join('\n');
+
+  return bluebird.resolve(links);
+}
+
 /**
  * Add the scripts and styles to the HTML string
  *
  * @param {object} mediaMap
  * @returns {Promise}
  */
-function append(mediaMap) {
-
-  // TODO: Put some warnings around the object passed in?
-
+function append(mediaMap, editMode = false, site) {
   return function (html) {
-    // assertion
-    if (!_.isString(html)) {
+    var mediaProps = {}; // The object which we'll use in bluebird.props
+
+    // Check that HTML is string
+    if (typeof html !== 'string') {
       throw new Error('Missing html parameter');
     }
 
-    return bluebird.props({
-      styles: combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG),
-      scripts: combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG)
-    }).then(combinedFiles => {
+    if (!editMode) {
+      mediaProps.styles = combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG);
+      mediaProps.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
+    } else {
+      mediaProps.styles = injectTags(mediaMap.styles, site, STYLE_TAG);
+      mediaProps.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
+    }
+
+    return bluebird.props(mediaProps).then(combinedFiles => {
       html = combinedFiles.styles ? appendMediaToTop(combinedFiles.styles, html) : html;     // If there are styles, append them
       html = combinedFiles.scripts ? appendMediaToBottom(combinedFiles.scripts, html) : html; // If there are scripts, append them
       return html;                                                                           // Return the compiled HTML

--- a/lib/media.js
+++ b/lib/media.js
@@ -142,7 +142,11 @@ function appendMediaToBottom(scripts, html) {
 
 function injectTags(fileArray, site, tag) {
   var links = _.map(fileArray, function (file) {
-    return `<link rel="stylesheet" type="text/css" href="${site.assetPath}${file}">`
+    if (tag === STYLE_TAG) {
+      return `<link rel="stylesheet" type="text/css" href="${site.assetPath}${file}">`
+    } else {
+      return `<script type="text/javascript" src="${site.assetPath}${file}"></script>`
+    }
   }).join('\n');
 
   return bluebird.resolve(links);
@@ -168,7 +172,7 @@ function append(mediaMap, editMode = false, site) {
       mediaProps.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
     } else {
       mediaProps.styles = injectTags(mediaMap.styles, site, STYLE_TAG);
-      mediaProps.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
+      mediaProps.scripts = injectTags(mediaMap.scripts, site, SCRIPT_TAG);
     }
 
     return bluebird.props(mediaProps).then(combinedFiles => {

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -12,11 +12,15 @@ describe(_.startCase(filename), function () {
     basicHtml = '<html><head></head><body></body></html>',
     basicSection = '<section><header></header><footer></footer></section>',
     styleString = '.test { color: red; }',
+    linkString = '/css/article.css',
+    tagString = '/js/a.js',
     scriptString = 'console.log("Tests!");',
     componentStyleHtml = '<html><head><style>' + styleString + '</style></head><body></body></html>',
     componentScriptHtml = '<html><head></head><body><script type="text/javascript">' + scriptString + '</script></body></html>',
     componentStyleSection = '<section><style>' + styleString + '</style><header></header><footer></footer></section>',
-    componentScriptSection = '<section><header></header><footer></footer><script type="text/javascript">' + scriptString + '</script></section>';
+    componentLinkedSection = `<section><link rel="stylesheet" type="text/css" href="${linkString}"><header></header><footer></footer></section>`,
+    componentScriptSection = '<section><header></header><footer></footer><script type="text/javascript">' + scriptString + '</script></section>',
+    componentTaggedSection = `<section><header></header><footer></footer><script type="text/javascript" src="${tagString}"></script></section>`;
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
@@ -25,6 +29,8 @@ describe(_.startCase(filename), function () {
 
   afterEach(function () {
     sandbox.restore();
+    lib.editStylesTags = false;
+    lib.editScriptsTags = false;
   });
 
 
@@ -39,7 +45,36 @@ describe(_.startCase(filename), function () {
     scriptMediaMap = {
       scripts: ['/js/a.js'],
       styles: []
+    },
+    fakeSite = {
+      slug: 'fake',
+      assetPath: ''
     };
+
+  describe('configure', function () {
+    const fn = lib[this.title];
+
+    it('sets both edit styles and scripts to true if a boolean is passed in', function () {
+      fn(true);
+
+      expect(lib.editStylesTags).to.be.true;
+      expect(lib.editScriptsTags).to.be.true;
+    });
+
+    it('sets both edit styles and scripts to false if a boolean is passed in', function () {
+      fn(false);
+
+      expect(lib.editStylesTags).to.be.false;
+      expect(lib.editScriptsTags).to.be.false;
+    });
+
+    it('uses object properties to set the values', function () {
+      fn({ styles: true, scripts: false });
+
+      expect(lib.editStylesTags).to.be.true;
+      expect(lib.editScriptsTags).to.be.false;
+    });
+  });
 
   describe('append', function () {
     const fn = lib[this.title];
@@ -83,9 +118,12 @@ describe(_.startCase(filename), function () {
         expect(html).to.deep.equal(componentStyleSection);
       }
 
+      function resolveLinkedSection(html) {
+        expect(html).to.deep.equal(componentLinkedSection);
+      }
+
       // Body HTML
       it('adds to bottom of head', function () {
-
         files.readFilePromise.onCall(0).returns(Promise.resolve(styleString));
 
         fn(cssMediaMap)(basicHtml)
@@ -107,6 +145,20 @@ describe(_.startCase(filename), function () {
         fn(cssMediaMap)(basicSection)
           .then(resolveSection);
       });
+
+      it('it checks for inlining vs script tags if edit mode', function () {
+        files.readFilePromise.onCall(0).returns(Promise.resolve(styleString));
+
+        fn(cssMediaMap, true)(basicSection)
+          .then(resolveSection);
+      });
+
+      it('inlines styles in edit mode if the options', function () {
+        lib.configure({ styles: true, scripts: false });
+
+        fn(cssMediaMap, true, fakeSite)(basicSection)
+          .then(resolveLinkedSection);
+      });
     });
 
     describe('with scripts', function () {
@@ -116,6 +168,10 @@ describe(_.startCase(filename), function () {
 
       function resolveSection(html) {
         expect(html).to.deep.equal(componentScriptSection);
+      }
+
+      function resolveTaggedSection(html) {
+        expect(html).to.deep.equal(componentTaggedSection);
       }
 
       it('adds to bottom of body', function () {
@@ -130,6 +186,13 @@ describe(_.startCase(filename), function () {
 
         fn(scriptMediaMap)(basicSection)
           .then(resolveSection);
+      });
+
+      it('inlines styles in edit mode if the options', function () {
+        lib.configure({ styles: false, scripts: true });
+
+        fn(scriptMediaMap, true, fakeSite)(basicSection)
+          .then(resolveTaggedSection);
       });
     });
   });

--- a/lib/render.js
+++ b/lib/render.js
@@ -39,7 +39,7 @@ function render(data) {
   }
 
   return Promise.resolve(rootPartial(composedData))
-    .then(mediaService.append(data._media))
+    .then(mediaService.append(data._media, data.locals.edit, data.locals.site))
     .then(result => {
       return {
         output: result,

--- a/lib/render.js
+++ b/lib/render.js
@@ -10,8 +10,9 @@ var hbs;
  * Create the object passed to the partial for rendering.
  * Remember, Kiln is expecting certain things in the object,
  * but it doesn't expect the FULL
- * @param  {[type]} data [description]
- * @return {[type]}      [description]
+ *
+ * @param  {Object} data
+ * @return {Object}
  */
 function composeData(data) {
   return  _.assign({
@@ -45,13 +46,15 @@ function render(data) {
         output: result,
         type: 'html'
       };
-    })
-    .catch(e => {
-      throw e;
     });
 }
 
+function configure({ editAssetTags }) {
+  mediaService.configure(editAssetTags);
+}
+
 module.exports = render;
+module.exports.configure = configure;
 module.exports.setHbs = function (val) {
   hbs = val;
 };

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -76,4 +76,13 @@ describe(_.startCase(filename), function () {
       expect(result).to.throw(Error);
     });
   });
+
+  describe('configure', function () {
+    const fn = lib[this.title];
+
+    it('calls the mediaService configure function', function () {
+      fn({ editAssetTags: true });
+      sinon.assert.calledOnce(mediaService.configure)
+    });
+  });
 });

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -172,13 +172,19 @@ function addHelpers(payload) {
   });
 }
 
+function configureRender(options) {
+  module.exports.renderSettings = options;
+}
+
 // Values assigned via functions post-instantiation
 module.exports.rootPath = null;
 module.exports.hbs = null;
+module.exports.renderSettings = null;
 
 // Setup functions
 module.exports.addRootPath = addRootPath;
 module.exports.addHelpers = addHelpers;
+module.exports.configureRender = configureRender;
 
 // For Testing
 module.exports.assignPkg = assignPkg;

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -172,7 +172,13 @@ function addHelpers(payload) {
   });
 }
 
+/**
+ * Pass settings to the renderer
+ *
+ * @param  {Object} options
+ */
 function configureRender(options) {
+  render.configure(options);
   module.exports.renderSettings = options;
 }
 

--- a/lib/setup.test.js
+++ b/lib/setup.test.js
@@ -5,6 +5,7 @@ const _ = require('lodash'),
   lib = require('./' + filename),
   files = require('nymag-fs'),
   path = require('path'),
+  render = require('./render'),
   nymagHbs = require('nymag-handlebars'),
   hbs = nymagHbs(),
   expect = require('chai').expect,
@@ -16,6 +17,7 @@ describe(_.startCase(filename), function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create();
+    sandbox.stub(render, 'configure');
   });
 
   afterEach(function () {
@@ -64,6 +66,22 @@ describe(_.startCase(filename), function () {
       sandbox.stub(hbs, 'registerPartial');
       fn(FAKE_ROOT);
       expect(hbs.registerPartial.calledOnce).to.be.false;
+    });
+  });
+
+  describe('configureRender', function () {
+    const fn = lib[this.title];
+
+    it('calls the render `configure` function', function () {
+      fn({ foo: 'bar' });
+
+      sinon.assert.calledOnce(render.configure);
+    });
+
+    it('exposes the render options on the module', function () {
+      fn({ foo: 'bar' });
+
+      expect(lib.renderSettings).to.eql({ foo: 'bar' });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "An HTML renderer for component data",
   "main": "index.js",
   "scripts": {
-    "test": "npm run eslint && npm run test-suite",
+    "test": "npm run eslint && npm run mocha",
     "eslint": "eslint --max-warnings 0 lib test",
-    "test-suite": "istanbul cover _mocha"
+    "mocha": "istanbul cover _mocha"
   },
   "dependencies": {
     "bluebird": "^3.5.0",


### PR DESCRIPTION
Allows for configuration of edit mode assets, either inlining them or allowing them to be linked to. At instantiation of Amphora HTML just configure with an object, like so:

```javascript
amphoraHtml.configureRender({
    editAssetTags: {
      styles: true,
      scripts: true
    }
  });
```

Want to do both at once?

```javascript
amphoraHtml.configureRender({
    editAssetTags: true
  });
```

Allows for individual configuration of scripts and styles