### PR TITLE
plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,8 @@ An amphora plugin is an object with a `render` function like this:
 
 ```javascript
 
-module.exports.render = data => {
-  /* `data` has the following keys:
-    - 'site'
-    - 'locals'
-    - '_self'
-    - '_pageData'
-    - '_version'
-    - '_layoutRef'
-    - '_components'
-    - '_componentSchemas'
-    - '_data'
-    - '_media'
-  */
-
-  // you can mutate at will
+module.exports.render = (ref, data, locals) => {
+  // you have the option to mutate `data` here
 
   // return `data` or a promise for `data`
   return data

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Amphora HTML
 
-The HTML renderer for Clay components that use [Handlebars](http://handlebarsjs.com/) templates.
+The HTML renderer for Clay components that use [Handlebars](http://handlebarsjs.com/) templates. 
 
 ## Install
 `$ npm install --save amphora-html`
@@ -10,6 +10,8 @@ The HTML renderer for Clay components that use [Handlebars](http://handlebarsjs.
 HTML rendering was controlled entirely by [Amphora](https://github.com/nymag/amphora) in v2.x, which meant that Amphora was responsible for a lot of heavy lifting. Furthermore, rendering was handled by a module called [Multiplex Templates](https://www.npmjs.com/package/multiplex-templates) which did some :crystal_ball: dark magic :sparkles: to synchronously render component templates. This required some affordances from Amphora which added to the weight of the middleware. By separating renderers out into separate modules which can be plugged into Amphora >v2.x we can create renderers for specific requirements (XML, Amp, etc.) _and_ the rendering process can be moved to separate machines to create more maintainable systems.
 
 ## Integration
+
+### Basic Configuration
 
 First, ensure that you have a compatible version of Amphora installed (v3.x or greater) and require `amphora-html` at the from wherever you are running Amphora.
 
@@ -24,6 +26,8 @@ Second, register a `rootPath` with the renderer. This will allow the renderer to
 // Register a root path for Amphora HTML
 amphoraHtml.addRootPath(path.dirname(path.resolve('./package.json')));
 ```
+
+### Handlebars Helpers
 
 If your templates require any custom [Handlebars Helpers](http://handlebarsjs.com/block_helpers.html) you can register them with the renderer's Handlebars instance. Simply pass in an object whose keys are the names of your helpers and whose values are the helper themselves. Like so:
 
@@ -41,7 +45,22 @@ const helpers = {
 amphoraHtml.addHelpers(helpers);
 ```
 
-You can add amphora-html plugins like this:
+### Amphora HTML Plugins
+
+Amphora HTML plugins let you read and modify the data used in rendering just before rendering occurs. An amphora plugin is an object with a `render` function like this:
+
+```javascript
+
+module.exports.render = (ref, data, locals) => {
+  // you have the option to mutate `data` here
+  // do **not** attempt to mutate `locals`
+
+  // return `data` or a promise for `data`
+  return data
+};
+```
+
+You can add Amphora HTML plugins like this:
 
 ```javascript
 amphoraHtml.addPlugins([
@@ -50,21 +69,15 @@ amphoraHtml.addPlugins([
 ]);
 ```
 
-An amphora plugin is an object with a `render` function like this:
+One use case for amphora plugins is to skip rendering of certain components depending on query parameters, which are available in `locals.query`. A current limitation of the plugin system is that amphora-html plugins do not currently enable you to edit the list of static assets used in rendering.
 
-```javascript
-
-module.exports.render = (ref, data, locals) => {
-  // you have the option to mutate `data` here
-
-  // return `data` or a promise for `data`
-  return data
-};
-```
+> We plan to add more hooks in the future and may put amphora-html in charge of [resolving media](https://github.com/clay/amphora-html/issues/14). Please file an issue if you want more functionality to be added.
 
 > Amphora plugins are skipped in edit mode.
 
-Now that you have registered your helpers and plugins and provided a root path which Amphora HTML can work from, you can register your renderer with Amphora. Registering consists of providing a `renderers` object whose keys are the extension of an HTTP request and whose values are the renderer. You can also specify a `default` property whose value is the extension that Amphora should default to when rendering. This is handy for rendering routes who don't end in extensions, such as `mycoolsite.com/about/`.
+### Register Amphora HTML with your Amphora Instance
+
+Now that you have registered any helpers and plugins and have provided a root path which Amphora HTML can work from, you can register your renderer with Amphora. Registering consists of providing a `renderers` object whose keys are the extension of an HTTP request and whose values are the renderer. You can also specify a `default` property whose value is the extension that Amphora should default to when rendering. This is handy for rendering routes who don't end in extensions, such as `mycoolsite.com/about/`.
 
 ```javascript
 return amphora({

--- a/README.md
+++ b/README.md
@@ -41,7 +41,41 @@ const helpers = {
 amphoraHtml.addHelpers(helpers);
 ```
 
-Now that you have registered your helpers and provided a root path which Amphora HTML can work from, you can register your renderer with Amphora. Registering consists of providing a `renderers` object whose keys are the extension of an HTTP request and whose values are the renderer. You can also specify a `default` property whose value is the extension that Amphora should default to when rendering. This is handy for rendering routes who don't end in extensions, such as `mycoolsite.com/about/`.
+You can add amphora-html plugins like this:
+
+```javascript
+amphoraHtml.addPlugins([
+  plugin1,
+  plugin2
+]);
+```
+
+An amphora plugin is an object with a `render` function like this:
+
+```javascript
+
+module.exports.render = data => {
+  /* `data` has the following keys:
+    - 'site'
+    - 'locals'
+    - '_self'
+    - '_pageData'
+    - '_version'
+    - '_layoutRef'
+    - '_components'
+    - '_componentSchemas'
+    - '_data'
+    - '_media'
+  */
+
+  // you can mutate at will
+
+  // return `data` or a promise for `data`
+  return data
+};
+```
+
+Now that you have registered your helpers and plugins and provided a root path which Amphora HTML can work from, you can register your renderer with Amphora. Registering consists of providing a `renderers` object whose keys are the extension of an HTTP request and whose values are the renderer. You can also specify a `default` property whose value is the extension that Amphora should default to when rendering. This is handy for rendering routes who don't end in extensions, such as `mycoolsite.com/about/`.
 
 ```javascript
 return amphora({

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ module.exports.render = (ref, data, locals) => {
 };
 ```
 
+> Amphora plugins are skipped in edit mode.
+
 Now that you have registered your helpers and plugins and provided a root path which Amphora HTML can work from, you can register your renderer with Amphora. Registering consists of providing a `renderers` object whose keys are the extension of an HTTP request and whose values are the renderer. You can also specify a `default` property whose value is the extension that Amphora should default to when rendering. This is handy for rendering routes who don't end in extensions, such as `mycoolsite.com/about/`.
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -5,4 +5,5 @@ const setup = require('./lib/setup');
 module.exports.render = require('./lib/render');
 module.exports.addRootPath = setup.addRootPath;
 module.exports.addHelpers = setup.addHelpers;
+module.exports.addPlugins = setup.addPlugins;
 module.exports.configureRender = setup.configureRender;

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,0 +1,44 @@
+'use strict';
+// adapted from https://github.com/clay/amphora-search/blob/cf4c8af/lib/services/log.js
+
+const clayLog = require('clay-log'),
+  pkg = require('../package.json');
+
+let amphoraHtmlLogInstance = null,
+  isInitialized = false;
+
+/**
+* Initialize the logger
+*/
+function ensureInitialized() {
+  if (isInitialized) {
+    return;
+  }
+  isInitialized = true;
+
+  clayLog.init({
+    name: 'amphora-html',
+    prettyPrint: true,
+    meta: {
+      amphorHtmlVersion: pkg.version
+    }
+  });
+
+  // Store the instance
+  amphoraHtmlLogInstance = clayLog.getLogger();
+}
+
+/**
+* Setup new logger for a file
+*
+* @param  {Object} meta
+* @return {Function}
+*/
+function setup(meta) {
+  ensureInitialized();
+  return clayLog.meta(meta, amphoraHtmlLogInstance);
+}
+
+module.exports = {
+  setup
+};

--- a/lib/render.js
+++ b/lib/render.js
@@ -36,6 +36,10 @@ function composeData(data) {
  * @returns data
  */
 function applyRenderHooks(ref, data, locals) {
+  // skip render hooks in edit mode
+  if (locals.edit) {
+    return bluebird.resolve(data);
+  }
   return bluebird.reduce(setup.plugins, (data, plugin) => {
     return plugin.render(ref, data, locals);
   }, data);

--- a/lib/render.js
+++ b/lib/render.js
@@ -27,6 +27,21 @@ function composeData(data) {
 }
 
 /**
+ * Applies `render` hooks.
+ * Render hooks each return `data` or a Promise for `data`.
+ *
+ * @param {String} ref
+ * @param {Object} data
+ * @param {Object} locals
+ * @returns data
+ */
+function applyRenderHooks(ref, data, locals) {
+  return bluebird.reduce(setup.plugins, (data, plugin) => {
+    return plugin.render(ref, data, locals);
+  }, data);
+}
+
+/**
  * Take in the data returned from Amphora, call `render` hooks,
  * and return HTML output.
  *
@@ -34,15 +49,10 @@ function composeData(data) {
  * @return {Promise<String>} html
  */
 function render(data) {
+  return applyRenderHooks(data._layoutRef, data._data, data.locals)
+  .then(_data => {
+    data._data = _data;
 
-  const hooks = _.chain(setup.plugins)
-                  .map('render')
-                  .compact()
-                  .value();
-
-  return bluebird.reduce(hooks, (data, hook) => hook(data), data)
-  .then(data => {
-    // console.log(JSON.stringify(data, null, 2));
     const template = clayUtils.getComponentName(data._layoutRef || data._self),
       rootPartial = hbs.partials[template],
       composedData = composeData(data);

--- a/lib/render.js
+++ b/lib/render.js
@@ -2,7 +2,9 @@
 
 const _ = require('lodash'),
   mediaService = require('./media'),
-  clayUtils = require('clay-utils');
+  clayUtils = require('clay-utils'),
+  bluebird = require('bluebird'),
+  setup = require('./setup');
 
 var hbs;
 
@@ -25,28 +27,39 @@ function composeData(data) {
 }
 
 /**
- * Take in the data returned from Amphora and turn it into HTML output.
+ * Take in the data returned from Amphora, call `render` hooks,
+ * and return HTML output.
  *
  * @param  {Object} data
- * @return {Promise}
+ * @return {Promise<String>} html
  */
 function render(data) {
-  const template = clayUtils.getComponentName(data._layoutRef || data._self),
-    rootPartial = hbs.partials[template],
-    composedData = composeData(data);
 
-  if (!rootPartial) {
-    throw new Error(`Missing template for ${data.template}`);
-  }
+  const hooks = _.chain(setup.plugins)
+                  .map('render')
+                  .compact()
+                  .value();
 
-  return Promise.resolve(rootPartial(composedData))
-    .then(mediaService.append(data._media, data.locals.edit, data.locals.site))
-    .then(result => {
-      return {
-        output: result,
-        type: 'html'
-      };
-    });
+  return bluebird.reduce(hooks, (data, hook) => hook(data), data)
+  .then(data => {
+    // console.log(JSON.stringify(data, null, 2));
+    const template = clayUtils.getComponentName(data._layoutRef || data._self),
+      rootPartial = hbs.partials[template],
+      composedData = composeData(data);
+
+    if (!rootPartial) {
+      throw new Error(`Missing template for ${data.template}`);
+    }
+
+    return rootPartial(composedData);
+  })
+  .then(mediaService.append(data._media, data.locals.edit, data.locals.site))
+  .then(result => {
+    return {
+      output: result,
+      type: 'html'
+    };
+  });
 }
 
 function configure({ editAssetTags, cacheBuster }) {

--- a/lib/render.js
+++ b/lib/render.js
@@ -33,7 +33,7 @@ function composeData(data) {
  * @param {String} ref
  * @param {Object} data
  * @param {Object} locals
- * @returns data
+ * @returns {Object} data
  */
 function applyRenderHooks(ref, data, locals) {
   // skip render hooks in edit mode

--- a/lib/render.js
+++ b/lib/render.js
@@ -36,12 +36,16 @@ function composeData(data) {
  * @returns {Object} data
  */
 function applyRenderHooks(ref, data, locals) {
+  let localsClone;
+
   // skip render hooks in edit mode
   if (locals.edit) {
     return bluebird.resolve(data);
   }
+
+  localsClone = _.cloneDeep(locals);
   return bluebird.reduce(setup.plugins, (data, plugin) => {
-    return plugin.render(ref, data, locals);
+    return plugin.render(ref, data, localsClone);
   }, data);
 }
 

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -65,16 +65,43 @@ describe(_.startCase(filename), function () {
       return lib(data).then(html => expect(html.output).to.deep.equal('<div></div>'));
     });
 
-    it('throws an error if a template is not found', function () {
-      var data = mockData(),
-        result = function () {
-          lib(data);
-        };
+    it('given a template is not found, returns a reject promise', function (done) {
+      const data = mockData();
 
       data._self = 'site.com/components/bar/instances/bar';
       lib.setHbs(hbs);
-      expect(result).to.throw(Error);
+
+      lib(data).catch(err => {
+        expect(err).to.be.an('Error');
+        done();
+      });
+
     });
+
+    it("'calls hooks from plugins' `render` functions", () => {
+      const data = mockData();
+
+      data._self = 'site.com/pages/index';
+      data._layoutRef = 'site.com/components/layout/instances/foo';
+      sandbox.stub(hbs.partials, 'layout').returns('<html></html>');
+
+      let calledWith;
+
+      require('./setup').plugins.push({
+        render(data) {
+          calledWith = data;
+          return data;
+        }
+      });
+
+      lib.setHbs(hbs);
+      return lib(data)
+        .then(html => {
+          // expect(html.output).to.equal('<html></html>');
+          expect(calledWith).to.equal(data);
+        });
+    });
+
   });
 
   describe('configure', function () {

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -6,7 +6,8 @@ const _ = require('lodash'),
   files = require('nymag-fs'),
   mediaService = require('./media'),
   expect = require('chai').expect,
-  sinon = require('sinon');
+  sinon = require('sinon'),
+  setup = require('./setup');
 
 describe(_.startCase(filename), function () {
   let sandbox;
@@ -72,34 +73,40 @@ describe(_.startCase(filename), function () {
       lib.setHbs(hbs);
 
       lib(data).catch(err => {
-        expect(err).to.be.an('Error');
+        expect(err.constructor).to.equal(Error);
         done();
       });
 
     });
 
     it("'calls hooks from plugins' `render` functions", () => {
-      const data = mockData();
+      const data = Object.assign({}, mockData(), {
+          _data: 'some data',
+          _self: 'site.com/pages/index',
+          _layoutRef: 'site.com/components/layout/instances/foo',
+        }),
+        clearPlugins = () => setup.plugins.splice(0, setup.plugins.length);
 
-      data._self = 'site.com/pages/index';
-      data._layoutRef = 'site.com/components/layout/instances/foo';
       sandbox.stub(hbs.partials, 'layout').returns('<html></html>');
 
       let calledWith;
 
-      require('./setup').plugins.push({
-        render(data) {
-          calledWith = data;
-          return data;
+      setup.addPlugins([
+        {
+          render(ref, data, locals) { // eslint-disable-line no-unused-vars
+            calledWith = [ref, data, locals];
+            return data;
+          }
         }
-      });
+      ]);
 
       lib.setHbs(hbs);
       return lib(data)
         .then(html => {
-          // expect(html.output).to.equal('<html></html>');
-          expect(calledWith).to.equal(data);
-        });
+          expect(html.output).to.equal('<html></html>');
+          expect(calledWith).to.deep.equal([data._layoutRef, data._data, data.locals]);
+        })
+        .finally(clearPlugins);
     });
 
   });

--- a/lib/render.test.js
+++ b/lib/render.test.js
@@ -79,7 +79,7 @@ describe(_.startCase(filename), function () {
 
     });
 
-    it("'calls hooks from plugins' `render` functions", () => {
+    it("Given it is not edit mode, calls hooks from plugins' `render` functions", () => {
       const data = Object.assign({}, mockData(), {
           _data: 'some data',
           _self: 'site.com/pages/index',
@@ -109,6 +109,38 @@ describe(_.startCase(filename), function () {
         .finally(clearPlugins);
     });
 
+    it("Given it is edit mode, skips hooks from plugins' `render` functions", () => {
+      const data = Object.assign({}, mockData(), {
+          locals: {
+            edit: true
+          },
+          _data: 'some data',
+          _self: 'site.com/pages/index',
+          _layoutRef: 'site.com/components/layout/instances/foo',
+        }),
+        clearPlugins = () => setup.plugins.splice(0, setup.plugins.length);
+
+      sandbox.stub(hbs.partials, 'layout').returns('<html></html>');
+
+      let calledWith = null;
+
+      setup.addPlugins([
+        {
+          render(ref, data, locals) { // eslint-disable-line no-unused-vars
+            calledWith = [ref, data, locals];
+            return data;
+          }
+        }
+      ]);
+
+      lib.setHbs(hbs);
+      return lib(data)
+        .then(html => {
+          expect(html.output).to.equal('<html></html>');
+          expect(calledWith).to.equal(null);
+        })
+        .finally(clearPlugins);
+    });
   });
 
   describe('configure', function () {

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -172,6 +172,16 @@ function addHelpers(payload) {
   });
 }
 
+let plugins = [];
+
+/**
+ *
+ * @param {Plugin[]} pluginsArr
+ */
+function addPlugins(pluginsArr) {
+  plugins.push.apply(plugins, pluginsArr);
+}
+
 /**
  * Pass settings to the renderer
  *
@@ -186,10 +196,12 @@ function configureRender(options) {
 module.exports.rootPath = null;
 module.exports.hbs = null;
 module.exports.renderSettings = null;
+module.exports.plugins = plugins;
 
 // Setup functions
 module.exports.addRootPath = addRootPath;
 module.exports.addHelpers = addHelpers;
+module.exports.addPlugins = addPlugins;
 module.exports.configureRender = configureRender;
 
 // For Testing

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -172,6 +172,17 @@ function addHelpers(payload) {
   });
 }
 
+/**
+ * If a plugin does not specify a render hook, this function will be used
+ * @param {String} ref
+ * @param {Object} data
+ * @param {Object} locals
+ * @returns {Object} data
+ */
+function defaultRenderHook(ref, data, locals) {// eslint-disable-line no-unused-vars
+  return data;
+}
+
 let plugins = [];
 
 /**
@@ -180,6 +191,7 @@ let plugins = [];
  */
 function addPlugins(pluginsArr) {
   plugins.push.apply(plugins, pluginsArr);
+  plugins.forEach(plugin => plugin.render = plugin.render || defaultRenderHook);
 }
 
 /**

--- a/lib/setup.js
+++ b/lib/setup.js
@@ -8,7 +8,8 @@ const path = require('path'),
   render = require('./render'),
   nymagHbs = require('nymag-handlebars'),
   hbs = nymagHbs(),
-  TEMPLATE_NAME = 'template';
+  TEMPLATE_NAME = 'template',
+  log = require('./log').setup({file: __filename});
 
 // Placeholder for the package.json and rootPath
 var pkg, rootPath;
@@ -172,17 +173,6 @@ function addHelpers(payload) {
   });
 }
 
-/**
- * If a plugin does not specify a render hook, this function will be used
- * @param {String} ref
- * @param {Object} data
- * @param {Object} locals
- * @returns {Object} data
- */
-function defaultRenderHook(ref, data, locals) {// eslint-disable-line no-unused-vars
-  return data;
-}
-
 let plugins = [];
 
 /**
@@ -190,8 +180,13 @@ let plugins = [];
  * @param {Plugin[]} pluginsArr
  */
 function addPlugins(pluginsArr) {
-  plugins.push.apply(plugins, pluginsArr);
-  plugins.forEach(plugin => plugin.render = plugin.render || defaultRenderHook);
+  pluginsArr.forEach((plugin, index) => {
+    if (plugin.render) {
+      plugins.push(plugin);
+    } else {
+      log('error', `Error in amphora-html addPlugins: No \`render\` func found for plugin at index ${index}`);
+    }
+  });
 }
 
 /**

--- a/lib/setup.test.js
+++ b/lib/setup.test.js
@@ -84,4 +84,28 @@ describe(_.startCase(filename), function () {
       expect(lib.renderSettings).to.eql({ foo: 'bar' });
     });
   });
+
+  describe('addPlugins', function () {
+    const fn = lib[this.title];
+
+    beforeEach(() => {
+      // clear plugins
+      lib.plugins.splice(0, lib.plugins.length);
+    });
+
+    it ('adds plugins', () => {
+      fn([{
+        render(ref, data, locals) { // eslint-disable-line no-unused-vars
+          return data;
+        }
+      }]);
+      expect(lib.plugins).to.have.length(1);
+    });
+
+    it ('skips plugins with no `render` function', () => {
+      fn([{}]);
+      expect(lib.plugins).to.have.length(0);
+    });
+  });
+
 });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "bluebird": "^3.5.0",
+    "clay-log": "^1.2.0",
     "clay-utils": "^1.1.1",
     "glob": "^7.1.1",
     "handlebars": "^4.0.6",


### PR DESCRIPTION
Add the ability to create amphora-html plug-ins.
Currently offers a `render` hook.

From the README.md:

You can add amphora-html plugins like this:

```javascript
amphoraHtml.addPlugins([
  plugin1,
  plugin2
]);
```

An amphora plugin is an object with a `render` function. The README shows the function signature and usage and provides a rationale for plugins.