### PR TITLE
Path.join issue

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -236,7 +236,10 @@ function pathJoin(assetHost, assetPath, assetDir) {
   var assetDirLen = assetDir.length;
 
   return function (filePath) {
-    return path.join(assetHost || assetPath, filePath.substr(assetDirLen));
+    var pathToFile = filePath.substr(assetDirLen);
+
+    if (assetHost) return `${assetHost}${pathToFile}`;
+    return path.join(assetPath, pathToFile);
   };
 }
 

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -212,6 +212,16 @@ describe(_.startCase(filename), function () {
         slug: 'foo'
       })).to.deep.equal(['/js/name.js', '/js/name.foo.js']);
     });
+
+    it('uses the assetHost valye if one is passed in', function () {
+      files.fileExists.withArgs(`${process.cwd()}/public/js/name.js`).returns(true);
+      files.fileExists.withArgs(`${process.cwd()}/public/js/name.foo.js`).returns(true);
+
+      expect(fn('name', {
+        slug: 'foo',
+        assetHost: 'https://cache.foo.com'
+      })).to.deep.equal(['https://cache.foo.com/js/name.js', 'https://cache.foo.com/js/name.foo.js']);
+    });
   });
 
   describe('injectScriptsAndStyles', function () {

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -213,7 +213,7 @@ describe(_.startCase(filename), function () {
       })).to.deep.equal(['/js/name.js', '/js/name.foo.js']);
     });
 
-    it('uses the assetHost valye if one is passed in', function () {
+    it('uses the assetHost value if one is passed in', function () {
       files.fileExists.withArgs(`${process.cwd()}/public/js/name.js`).returns(true);
       files.fileExists.withArgs(`${process.cwd()}/public/js/name.foo.js`).returns(true);
 


### PR DESCRIPTION
Previously used path.join for merging file paths. When `assetHost` was thrown into the mix a small bug was discovered where `path.join('http://somesite.com', '/foo/bar')` will result in `http:/somesite.com/foo/bar`. 

Because it was `http:/` and not `http://`, the browser would bork.