### PR TITLE
Adds support for .client js files

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -189,7 +189,8 @@ function getScripts(name, site) {
 
   return _.map(_.filter([
     path.join(assetDir, 'js', `${name}.js`),
-    path.join(assetDir, 'js', `${name}.${slug}.js`)
+    path.join(assetDir, 'js', `${name}.${slug}.js`),
+    path.join(assetDir, 'js', `${name}.client.js`)
   ], files.fileExists), pathJoin(assetHost, assetPath, assetDir));
 }
 


### PR DESCRIPTION
This non-breaking change readies amphora-html for Clay installations that build client scripts with the megabundler, which exports client.js files to the asset directory with filenames that end with `.client.js` to distinguish them from other modules (e.g. `.services.js` indicates a global service). This naming convention prevents collisions with other modules and allows a client-side runtime script to easily identify client.js scripts and mount components with them.