### PR TITLE
Remove Memoization of stylguide#setDefaultVariations

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -92,4 +92,4 @@ function setDefaultVariations(_data, state) {
 }
 
 exports.getVariations = _.memoize(getVariations);
-exports.setDefaultVariations = _.memoize(setDefaultVariations);
+exports.setDefaultVariations = setDefaultVariations;


### PR DESCRIPTION
While testing amphoraHtml render times, I think I have found that the memoization of `styleguide#setDefaultVariations` should be removed.  Consider the following example:

```js
'use strict';

const assert = require('assert'),
  styleguideService = require('./amphora-html@3.4.4/lib/styleguide'),
  // Page Data received from amphora's composition phase
  _data = {
    main: [
      {
        _ref: 'localhost.example.com/_components/article/instance',
        content: [
          {
            _ref: 'localhost.example.com/_components/paragraph/instance'
          },
          {
            _ref: 'localhost.example.com/_components/image/instance'
          },
          {
            _ref: 'localhost.example.com/_components/paragraph/instance',
            componentVariation: 'paragraph_a'
          },
          {
            _ref: 'localhost.example.com/_components/image/instance'
          }
        ]
      }
    ],
    _version: 1.1
  },
  // Partial State Data received from amphoraHtml.render#makeState
  stateA = {
    _self: 'localhost.nymag.com/daily/intelligencer/_pages/cjjjcn84k008jkay6in7kt97k',
    _components: [
      'layout',
      'article',
      'paragraph',
      'image'
    ],
    _componentVariations: {
      paragraph: [
        'paragraph_a'
      ]
    },
    _layoutRef: 'localhost.nymag.com/daily/intelligencer/_components/layout/instances/article',
    locals: {
      site: {
        styleguide: 'selectall'
      }
    }
  },
  // Partial State Data received from amphoraHtml.render#makeState
  stateB = {
    _self: 'localhost.nymag.com/daily/intelligencer/_pages/cjjjcn84k008jkay6in7kt97k',
    _components: [
      'layout',
      'article',
      'paragraph',
      'image'
    ],
    _componentVariations: {
      paragraph: [
        'paragraph_a'
      ]
    },
    _layoutRef: 'localhost.nymag.com/daily/intelligencer/_components/layout/instances/article',
    locals: {
      site: {
        styleguide: 'selectall'
      }
    }
  };

styleguideService.setDefaultVariations(_data, stateA);
assert.ok(stateA._usedVariations); // assertion runs fine, _usedVariations exists
styleguideService.setDefaultVariations(_data, stateB);
assert.ok(stateB._usedVariations); // assertion throws, _usedVariations is not set on the state
```

Because of the memoization of the library method, unless the first parameter ([lodash's default cache key](https://lodash.com/docs/4.17.10#memoize)) changes then subsequent renders of the same page would never have their state updated to include necessary variation information.  The only way that this method would be re-run is if the page data is changing between renders, or the lodash cache is cleared, I am not sure that either is guaranteed to occur deterministically between renders.

Additionally, I think at a high level that since the method returns no value it should not be memoized.  If we need memoization of this method then it should be updated to replace the state instead of altering it in place.