### PR TITLE
Handle Top Level componentVariations

### DIFF
--- a/lib/styleguide.js
+++ b/lib/styleguide.js
@@ -60,8 +60,15 @@ function getVariations(styleguide = '_default') {
 function setDefaultVariations(_data, state) {
   const variations = state._componentVariations,
     layoutOrSelf = clayUtils.getComponentName(state._layoutRef || state._self),
+    /**
+     * When rendering data it's possible that the top level _data might also
+     * have a componentVariation (the simple example would be rendering an
+     * individual component), in that case we should make sure that we handle
+     * that as one of our usedVariations.
+     */
+    topLevelVariation = _data.componentVariation,
     usedVariations = {
-      [layoutOrSelf]: true
+      [topLevelVariation || layoutOrSelf]: true
     };
 
   traverse(_data).forEach(function (val) {

--- a/lib/styleguide.test.js
+++ b/lib/styleguide.test.js
@@ -248,4 +248,21 @@ describe(_.startCase(filename), () => {
     lib.setDefaultVariations(testData, state);
     expect(testData).toEqual(testData);
   });
+
+  test('handles top level componentVariations (when rendering an individual component with variation', () => {
+    let _data = {
+        _ref: 'nymag.com/daily/intelligencer/_components/blockquote/instances/foo@published',
+        componentVariation: 'blockquote_red',
+      },
+      state = {
+        _self: 'nymag.com/daily/intelligencer/_components/blockquote/instances/foo@published',
+        _layoutRef: undefined,
+        _componentVariations: lib.getVariations('di')
+      };
+
+    lib.setDefaultVariations(_data, state);
+    expect(state._usedVariations).toEqual([
+      'blockquote_red'
+    ]);
+  });
 });


### PR DESCRIPTION
When rendering items with top level component data (i.e. when rendering an individual component) we need to handle pulling in that top level componentVariation information, otherwise the correct styles will not be pulled in later down the line.

For example a component like `example.com/_components/foo/instances/bar` with data like:

```json
{
  "_ref": "example.com/_components/foo/instances/bar",
  "componentVariation": "foo_example"
}
```

when rendered directly, `example.com/_components/foo/instances/bar.html`, should pull in the `foo_example` styleguide instead of just pulling in the default variation `foo` based on the component name.