### PR TITLE
Explicitly require sshpk to avoid Security Vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2718,7 +2718,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "sshpk": "1.14.2"
       }
     },
     "iconv-lite": {
@@ -5173,6 +5173,12 @@
         "ret": "0.1.15"
       }
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
@@ -5548,9 +5554,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
@@ -5560,6 +5566,7 @@
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "^3.19.0",
-    "jest": "^23.4.1"
+    "jest": "^23.4.1",
+    "sshpk": "^1.14.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Similar to this issue https://github.com/clay/amphora-rss/pull/10 .  To avoid the security vulnerability of `sshpk@1.13.1` we should explicitly require the package ourselves at a stable version until the upstream package issues are resolved.