### PR TITLE
Fix asset URL construction.

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -6,6 +6,7 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   setup = require('./setup'),
   styleguide = require('./styleguide'),
+  url = require('url'),
   STYLE_TAG = 'style',
   SCRIPT_TAG = 'scripts',
   ASYNC_SCRIPT_TAG = 'async',
@@ -321,6 +322,7 @@ function getManifestAssets(state) {
   const site = state.locals.site,
     assetDir = site && site.assetDir || MEDIA_DIRECTORY,
     assetHost = site && site.assetHost || '/',
+    assetPath = site && site.assetPath || '',
     manifestName = site && site.manifestName || 'assets-manifest.json',
     manifestFile = path.resolve(path.join(assetDir, manifestName));
   let manifest;
@@ -339,7 +341,7 @@ function getManifestAssets(state) {
     return components.concat(assets);
   }, []);
 
-  return _.union(runtime, scriptFiles).map(script => path.join(assetHost, script));
+  return _.union(runtime, scriptFiles).map(script => url.resolve(assetHost, path.join(assetPath, script)));
 }
 
 /**

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -11,7 +11,7 @@ const _ = require('lodash'),
 jest.mock('nymag-fs', () => ({
   fileExists: () => false,
   readFilePromise: () => Promise.resolve(''),
-  tryRequire: () => undefined
+  tryRequire: () => ({})
 }));
 
 describe(_.startCase(filename), () => {
@@ -623,6 +623,82 @@ describe(_.startCase(filename), () => {
         ]);
       }
     );
+  });
+
+  describe('getManifestAssets', () => {
+    const fn = lib['getManifestAssets'];
+
+    describe('constructs the correct asset URL', () => {
+      test('when assetHost is configured', () => {
+        const assetHost = 'https://assets.nymag.com';
+        const localState = {
+          locals: {
+            site: {
+              assetHost
+            }
+          },
+          _components: [
+            'a',
+            'b'
+          ]
+        };
+        const manifest = {
+          entrypoints: {
+            a: {
+              assets: {
+                js: ['/a.js']
+              }
+            },
+            b: {
+              assets: {
+                js: ['b.js']
+              }
+            }
+          }
+        };
+
+        jest.spyOn(files, 'tryRequire').mockImplementation(() => manifest);
+
+        expect(fn(localState)).toEqual([
+          `${ assetHost }/a.js`,
+          `${ assetHost }/b.js`
+        ]);
+      });
+
+      test('when assetHost is not configured', () => {
+        const localState = {
+          locals: {
+            site: {
+            }
+          },
+          _components: [
+            'a',
+            'b'
+          ]
+        };
+        const manifest = {
+          entrypoints: {
+            a: {
+              assets: {
+                js: ['/a.js']
+              }
+            },
+            b: {
+              assets: {
+                js: ['b.js']
+              }
+            }
+          }
+        };
+
+        jest.spyOn(files, 'tryRequire').mockImplementation(() => manifest);
+
+        expect(fn(localState)).toEqual([
+          '/a.js',
+          '/b.js'
+        ]);
+      });
+    });
   });
 
   describe('injectScriptsAndStyles', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -480,6 +480,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-uniq": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+      "integrity": "sha1-X8w3OSB3VyPP1k1lxkvvU7+eum0=",
+      "dev": true
+    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
@@ -1062,6 +1068,74 @@
         "pino": "^4.7.1"
       }
     },
+    "clayhandlebars": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/clayhandlebars/-/clayhandlebars-5.0.1.tgz",
+      "integrity": "sha512-xUVD0yGtSD8taJ0WQbLNNER2UotdQ1ifrbt8R4kxjB0OYxZGmZdu4m05Cia/+m+znu0L4x2CsmxYSaT38/IZbg==",
+      "dev": true,
+      "requires": {
+        "comma-it": "0.0.7",
+        "date-fns": "^1.30.1",
+        "glob": "^7.1.6",
+        "handlebars": "^4.7.6",
+        "he": "^1.2.0",
+        "helper-yaml": "^0.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "outdent": "^0.3.0",
+        "randomstring": "^1.1.5",
+        "sinon": "^2.1.0",
+        "speakingurl": "^11.0.0",
+        "striptags": "^2.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.7",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+          "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "handlebars": {
+          "version": "4.7.7",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
+          "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5",
+            "neo-async": "^2.6.0",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4",
+            "wordwrap": "^1.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+          "dev": true
+        }
+      }
+    },
     "clayutils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clayutils/-/clayutils-3.0.0.tgz",
@@ -1174,6 +1248,12 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "comma-it": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/comma-it/-/comma-it-0.0.7.tgz",
+      "integrity": "sha1-MfRYG5xENCcxjO3/kfnKjQJLwxs=",
+      "dev": true
     },
     "commander": {
       "version": "2.20.0",
@@ -1320,6 +1400,12 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+      "dev": true
     },
     "debug": {
       "version": "2.6.9",
@@ -2012,6 +2098,15 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
+      }
+    },
+    "formatio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+      "dev": true,
+      "requires": {
+        "samsam": "1.x"
       }
     },
     "fragment-cache": {
@@ -2799,6 +2894,18 @@
           }
         }
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "helper-yaml": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/helper-yaml/-/helper-yaml-0.1.0.tgz",
+      "integrity": "sha1-iXsYk/gNugLcaoVqPLMJjbQm2SY=",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
@@ -3988,6 +4095,12 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
+    "lolex": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+      "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4212,6 +4325,12 @@
           "dev": true
         }
       }
+    },
+    "native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -4464,6 +4583,12 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "outdent": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.3.0.tgz",
+      "integrity": "sha1-+tGKnAYaCTjzjoBx0WxAJEI/QyM=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -4555,6 +4680,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "1.1.0",
@@ -4762,6 +4904,22 @@
           "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
           "dev": true
         }
+      }
+    },
+    "randombytes": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
+      "integrity": "sha1-Z0yZdgkBw8QRJ3GjHlIdw0nMCew=",
+      "dev": true
+    },
+    "randomstring": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/randomstring/-/randomstring-1.2.1.tgz",
+      "integrity": "sha512-eMnfell9XuU3jfCx3f4xCaFAt0YMFPZhx9R3PSStmLarDKg5j5vivqKhf/8pvG+VX/YkxsckHK/VPUrKa5V07A==",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.2",
+        "randombytes": "2.0.3"
       }
     },
     "read-pkg": {
@@ -5073,6 +5231,12 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "samsam": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sane": {
@@ -5453,6 +5617,22 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
+    "sinon": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.4.1.tgz",
+      "integrity": "sha512-vFTrO9Wt0ECffDYIPSP/E5bBugt0UjcBQOfQUMh66xzkyPEnhl/vM2LRZi2ajuTdkH07sA6DzrM6KvdvGIH8xw==",
+      "dev": true,
+      "requires": {
+        "diff": "^3.1.0",
+        "formatio": "1.2.0",
+        "lolex": "^1.6.0",
+        "native-promise-only": "^0.8.1",
+        "path-to-regexp": "^1.7.0",
+        "samsam": "^1.1.3",
+        "text-encoding": "0.6.4",
+        "type-detect": "^4.0.0"
+      }
+    },
     "sisteransi": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
@@ -5659,6 +5839,12 @@
       "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
+    "speakingurl": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-11.0.0.tgz",
+      "integrity": "sha1-IOXO/AmzL8/jnuCy6XiT+zkoGbM=",
+      "dev": true
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5804,6 +5990,12 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "striptags": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/striptags/-/striptags-2.2.1.tgz",
+      "integrity": "sha1-TEULcI1BuL85zyTEn/I0/Gqr/TI=",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -5919,6 +6111,12 @@
         "read-pkg-up": "^1.0.1",
         "require-main-filename": "^1.0.1"
       }
+    },
+    "text-encoding": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -6062,6 +6260,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "traverse": "^0.6.6"
   },
   "devDependencies": {
+    "clayhandlebars": "^5.0.1",
     "coveralls": "^3.0.2",
     "eslint": "^3.19.0",
     "jest": "23.6.0"


### PR DESCRIPTION
This fixes the artless construction of Webpack asset paths which caused last week's outage and adds unit tests to validate the change.