### PR TITLE
Ignore assetPath for CDN assets.

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -322,7 +322,6 @@ function getManifestAssets(state) {
   const site = state.locals.site,
     assetDir = site && site.assetDir || MEDIA_DIRECTORY,
     assetHost = site && site.assetHost || '/',
-    assetPath = site && site.assetPath || '',
     manifestName = site && site.manifestName || 'assets-manifest.json',
     manifestFile = path.resolve(path.join(assetDir, manifestName));
   let manifest;
@@ -341,7 +340,7 @@ function getManifestAssets(state) {
     return components.concat(assets);
   }, []);
 
-  return _.union(runtime, scriptFiles).map(script => url.resolve(assetHost, path.join(assetPath, script)));
+  return _.union(runtime, scriptFiles).map(script => url.resolve(assetHost, script));
 }
 
 /**

--- a/lib/media.test.js
+++ b/lib/media.test.js
@@ -698,6 +698,41 @@ describe(_.startCase(filename), () => {
           '/b.js'
         ]);
       });
+
+      test('without prepending assetPath', () => {
+        const localState = {
+          locals: {
+            site: {
+              assetPath: '/strategist'
+            }
+          },
+          _components: [
+            'a',
+            'b'
+          ]
+        };
+        const manifest = {
+          entrypoints: {
+            a: {
+              assets: {
+                js: ['/a.js']
+              }
+            },
+            b: {
+              assets: {
+                js: ['b.js']
+              }
+            }
+          }
+        };
+
+        jest.spyOn(files, 'tryRequire').mockImplementation(() => manifest);
+
+        expect(fn(localState)).toEqual([
+          '/a.js',
+          '/b.js'
+        ]);
+      });
     });
   });
 


### PR DESCRIPTION
This piece of the site config appears to help resolve things like image files for our sites that sit under thier own base URI, like _Intel_ and _Strat_. It's not relevant to where assets live on the CDN.