### PR TITLE
Initialize Webpack assets without Amphora.

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -332,7 +332,8 @@ function getManifestAssets(state) {
     return [];
   }
 
-  const scriptFiles = _.get(manifest, ['entrypoints', 'main', 'assets', 'js'], []);
+  const entrypoints = _.get(manifest, 'entrypoints', []);
+  const scriptFiles = _.flatMap(entrypoints, entrypoint => _.get(entrypoint, 'assets.js', []));
 
   return scriptFiles.map(script => url.resolve(assetHost, script));
 }

--- a/lib/media.js
+++ b/lib/media.js
@@ -201,7 +201,7 @@ function filterManifestComponents(state) {
 function getMediaMap(state) {
   return {
     styles: module.exports.getStyleFiles(state),
-    scripts: module.exports.getScriptFiles(state),
+    scripts: [],
     manifestAssets: module.exports.getManifestAssets(state)
   };
 }
@@ -332,15 +332,9 @@ function getManifestAssets(state) {
     return [];
   }
 
-  const runtime = _.get(manifest, 'runtime.js', '');
+  const scriptFiles = _.get(manifest, ['entrypoints', 'main', 'assets', 'js'], []);
 
-  const scriptFiles = [...state._components, '__clay_globals', '__clay_client_init'].reduce((components, component) => {
-    const assets = _.get(manifest, ['entrypoints', component, 'assets', 'js'], []);
-
-    return components.concat(assets);
-  }, []);
-
-  return _.union(runtime, scriptFiles).map(script => url.resolve(assetHost, script));
+  return scriptFiles.map(script => url.resolve(assetHost, script));
 }
 
 /**

--- a/lib/media.js
+++ b/lib/media.js
@@ -201,7 +201,7 @@ function filterManifestComponents(state) {
 function getMediaMap(state) {
   return {
     styles: module.exports.getStyleFiles(state),
-    scripts: [],
+    scripts: module.exports.getScriptFiles(state),
     manifestAssets: module.exports.getManifestAssets(state)
   };
 }
@@ -407,28 +407,17 @@ function injectScriptsAndStyles(state) {
 
     if (!locals.edit) {
       mediaMap.styles = combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG);
-      mediaMap.scripts = combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
-
-      // TODO: Ideally, we'd load these scripts asynchronously or after the DOM
-      // is ready, setting the `async` attribute, the `defer` attribute, or
-      // both. Because the order in which they're parsed and executed currently
-      // matters, we can't do that safely.
-      mediaMap.manifestAssets = injectTags(mediaMap.manifestAssets, locals.site, SCRIPT_TAG);
+      mediaMap.scripts = !!mediaMap.manifestAssets && mediaMap.manifestAssets.length > 0
+        ? injectTags(mediaMap.manifestAssets, locals.site, ASYNC_DEFER_SCRIPT_TAG)
+        : combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
     } else {
       mediaMap.styles = module.exports.editStylesTags ? injectTags(mediaMap.styles, locals.site, STYLE_TAG) : combineFileContents(mediaMap.styles, 'public/css', '/css/', STYLE_TAG);
       mediaMap.scripts = module.exports.editScriptsTags ? injectTags(mediaMap.scripts, locals.site, SCRIPT_TAG) : combineFileContents(mediaMap.scripts, 'public/js', '/js/', SCRIPT_TAG);
-
-      // FIXME: Some of the logic which excludes client-side scripts from edit
-      // mode sits with nymag/sites, in the `resolve-media` module, and some
-      // lives here. Since we're currently not using Webpack for Kiln and model
-      // assets, this feels like the best place to null out client scripts.
-      mediaMap.manifestAssets = null;
     }
 
     return bluebird.props(mediaMap)
       .then(combinedFiles => {
         html = combinedFiles.styles ? appendMediaToTop(combinedFiles.styles, html) : html; // If there are styles, append them
-        html = combinedFiles.manifestAssets ? appendMediaToBottom(combinedFiles.manifestAssets, html) : html; // If there are assets registered with the manifest, append them
         html = combinedFiles.scripts ? appendMediaToBottom(combinedFiles.scripts, html) : html; // If there are scripts, append them
         return html; // Return the compiled HTML
       });


### PR DESCRIPTION
These changes rework the Amphora logic for embedding `script` tags so that Webpack can load assets through its own runtime.