### PR TITLE
🍕 Fix docs deploy URL parsing in GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,7 +9,7 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -21,17 +21,19 @@ jobs:
           node-version: '16'
 
       - name: Install website dependencies
-        run: npm install
+        run: npm ci
         working-directory: website
 
       - name: Update Docusaurus version
-        uses: clay/docusaurus-github-action@f3ea5271a51c1f06e456d55e490993985210c02b
-        with:
-          args: version
+        run: npm run version
+        working-directory: website
 
-      - name: Build and publish to gh-pages
-        uses: clay/docusaurus-github-action@f3ea5271a51c1f06e456d55e490993985210c02b
-        env:
-          DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+      - name: Build Docusaurus site
+        run: npm run build
+        working-directory: website
+
+      - name: Publish docs to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          args: deploy
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./website/build/amphora-html

--- a/lib/media.js
+++ b/lib/media.js
@@ -6,7 +6,6 @@ const _ = require('lodash'),
   bluebird = require('bluebird'),
   setup = require('./setup'),
   styleguide = require('./styleguide'),
-  url = require('url'),
   STYLE_TAG = 'style',
   SCRIPT_TAG = 'scripts',
   MEDIA_DIRECTORY = path.join(process.cwd(), 'public');

--- a/lib/render.js
+++ b/lib/render.js
@@ -38,6 +38,8 @@ function applyRenderHooks(ref, data, locals) {
  *
  * @param {String} ref
  * @param {Object} locals
+ * @param {Object} res
+ * @param {Object} self
  * @returns {Function}
  */
 function applyPostRenderHooks(ref, locals, res, self) {


### PR DESCRIPTION
## Summary
- remove the custom `clay/docusaurus-github-action` deploy flow that builds an invalid repository URL in CI
- run docs versioning and build with explicit `npm` commands in `website/`
- publish docs to `gh-pages` using `peaceiris/actions-gh-pages` with `GITHUB_TOKEN`

## Why
The previous deploy step failed with an invalid URL error (`Invalid port in url`) during docs publish. This switches to a standard GitHub Pages deploy path that avoids that URL construction bug.

## Test plan
- [ ] Trigger `Deploy to GitHub Pages` workflow on this branch
- [ ] Confirm docs build succeeds and `gh-pages` publish step completes

Made with [Cursor](https://cursor.com)