### PR TITLE
🍕 Fix docs workflow install command for website

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '16'
 
       - name: Install website dependencies
-        run: npm ci
+        run: npm install
         working-directory: website
 
       - name: Update Docusaurus version


### PR DESCRIPTION
## Summary
- change docs deploy workflow step in `.github/workflows/push.yml` from `npm ci` to `npm install` for `website/`

## Why
The docs pipeline currently fails on `master` with:
`The npm ci command can only install with an existing package-lock.json`

`website/` does not contain a lockfile, so `npm ci` is not valid there.

## Test plan
- [ ] Run the `Deploy to GitHub Pages` workflow
- [ ] Confirm install/build/publish steps complete

Made with [Cursor](https://cursor.com)